### PR TITLE
Fix note length when chords share a pitch

### DIFF
--- a/chord_midi/gui/piano_roll.py
+++ b/chord_midi/gui/piano_roll.py
@@ -142,7 +142,11 @@ class PianoRoll(QGraphicsView):
             # start = int(it.x() * 480 / self.BAR_W)
             # 1 accord (BAR_W px)  →  `ticks`  (beats/chord * 480)
             start = int(it.x() * ticks / self.BAR_W)
-            ev += [(start,       'control_change', 10,  it.pan, ch),
-                   (start,       'note_on',        it.pitch, it.vel, ch),
-                   (start+ticks, 'note_off',       it.pitch, 0, ch)]
-        return sorted(ev, key=lambda t: t[0])
+            ev += [
+                (start,       'control_change', 10,  it.pan, ch),
+                (start,       'note_on',        it.pitch, it.vel, ch),
+                (start + ticks, 'note_off',       it.pitch, 0, ch),
+            ]
+
+        order = {'note_off': 0, 'control_change': 1, 'note_on': 2}
+        return sorted(ev, key=lambda t: (t[0], order.get(t[1], 3)))

--- a/chord_midi/midi/progression.py
+++ b/chord_midi/midi/progression.py
@@ -89,7 +89,7 @@ def build_midi(rprog: List[roman.RomanNumeral], out="progression.mid",
             events.append((clock + tick_bar, 'note_off', n, 0))
         clock += tick_bar
 
-    events.sort(key=lambda e: e[0])
+    events.sort(key=lambda e: (e[0], 0 if e[1] == 'note_off' else 1))
     prev = 0
     for t, typ, note, velocity in events:
         tr.append(Message(typ, note=note, velocity=velocity,


### PR DESCRIPTION
## Summary
- ensure note_off events are emitted before note_on at the same tick
- adjust build_midi and piano roll export to sort events with priority

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877e27aee588326a55d6d4d6b799034