### PR TITLE
Add pyproject and CLI entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *__pycache__*
 *.mid
+
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Ce projet propose une petite application graphique pour générer et éditer des
 
 ## Installation
 
-Clonez le dépôt puis installez les dépendances :
+Clonez le dépôt puis installez le projet (et ses dépendances) en mode éditable :
 
 ```bash
-pip install -r requirements.txt
+pip install -e .
 ```
 
 ## Utilisation

--- a/chord_midi/__main__.py
+++ b/chord_midi/__main__.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Point d’entrée pour l’interface graphique Chord-MIDI."""
+import sys
+from PySide6.QtWidgets import QApplication
+from .gui.main_window import ChordMidiWindow
+
+
+def main() -> None:
+    """Lance l’application graphique."""
+    app = QApplication(sys.argv)
+    w = ChordMidiWindow()
+    w.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "chord_midi"
+version = "0.1.0"
+description = "Application graphique pour générer des progressions d'accords et les exporter en MIDI"
+readme = "README.md"
+license = {file = "LICENSE"}
+requires-python = ">=3.10"
+authors = [{name = "cbCielblanc"}]
+dependencies = [
+    "PySide6",
+    "mido",
+    "music21"
+]
+
+[project.scripts]
+chord-midi = "chord_midi.__main__:main"


### PR DESCRIPTION
## Summary
- package project with a new **pyproject.toml**
- provide a CLI entry point in `chord_midi.__main__`
- ignore build artifacts
- update README to explain editable installation

## Testing
- `pip install -e .`
- `pip show chord_midi | head -n 6`

------
https://chatgpt.com/codex/tasks/task_e_6877ece05f3c8326a420b5cc5a401be8